### PR TITLE
Disable gzip compression for libraries

### DIFF
--- a/gulp/tasks/upload-bower-lib.js
+++ b/gulp/tasks/upload-bower-lib.js
@@ -22,9 +22,6 @@ gulp.task('upload-bower-lib', function() {
         path.basename = path.basename.replace('bastly', 'bastly-' + releaseVersion);
     }))
  
-    // gzip, Set Content-Encoding headers and add .gz extension 
-    .pipe(awspublish.gzip())
- 
     // publisher will add Content-Length, Content-Type and headers specified above 
     // If not specified it will set x-amz-acl to public-read by default 
     .pipe(publisher.publish(headers))


### PR DESCRIPTION
Disable gzip compression to let services like wget get libraries uncompressed
